### PR TITLE
fix: 修复当使用 volta 管理 node 版本的时候安装插件失败的问题

### DIFF
--- a/src/core/plugin-handler/index.ts
+++ b/src/core/plugin-handler/index.ts
@@ -36,7 +36,14 @@ class AdapterHandler {
       fs.mkdirsSync(options.baseDir);
       fs.writeFileSync(
         `${options.baseDir}/package.json`,
-        '{"dependencies":{}}'
+        // '{"dependencies":{}}'
+        // fix 插件安装时node版本问题
+        JSON.stringify({
+          dependencies: {},
+          volta: {
+            node: '16.19.1',
+          },
+        })
       );
     }
     this.baseDir = options.baseDir;


### PR DESCRIPTION
<img width="3214" height="1298" alt="f6d5602068b9316547d6c1c879ab87f0" src="https://github.com/user-attachments/assets/555f3ec3-988f-468c-9781-a6da13008205" />
