### PR TITLE
fix-subinput-change

### DIFF
--- a/src/renderer/plugins-manager/search.ts
+++ b/src/renderer/plugins-manager/search.ts
@@ -1,4 +1,5 @@
 import { reactive, toRefs } from 'vue';
+import { ipcRenderer } from 'electron';
 
 const searchManager = () => {
   const state = reactive({
@@ -14,6 +15,10 @@ const searchManager = () => {
 
   const setSearchValue = (value: string) => {
     state.searchValue = value;
+    ipcRenderer.sendSync('msg-trigger', {
+      type: 'sendSubInputChangeEvent',
+      data: { text: value },
+    });
   };
 
   window.setSubInput = ({ placeholder }: { placeholder: string }) => {


### PR DESCRIPTION
## 原因
如图所示的`@input`  触发 `targetSearch` 触发 `SubInputChange` 回调
<img width="928" height="555" alt="image" src="https://github.com/user-attachments/assets/004d86ca-229b-4846-946f-487b5dfe261d" />
<img width="951" height="182" alt="image" src="https://github.com/user-attachments/assets/f1a7f2c4-2631-468d-b536-45dbcf18c6cf" />
<img width="595" height="212" alt="image" src="https://github.com/user-attachments/assets/ee981dec-97e8-4f2d-81a4-fa1aa385748f" />

但是，hide 窗口触发 `clearSearchValue` 却不会触发 `SubInputChange` 回调
<img width="471" height="123" alt="image" src="https://github.com/user-attachments/assets/f534b112-9187-44f9-a247-db73dc7ed1c1" />

## 造成问题
导致如下视频问题，`clearSearchValue` 不会触发 `SubInputChange` 通知插件

https://github.com/user-attachments/assets/29362412-91a0-4ed0-8b88-5e59bb55b2a4

@muwoo 
